### PR TITLE
다중 프래그먼트 상황에서 로그아웃 기능 구현 (4시간 투자) - BKM 

### DIFF
--- a/app/src/main/java/com/bkm/worktalk/FragSettings.java
+++ b/app/src/main/java/com/bkm/worktalk/FragSettings.java
@@ -2,17 +2,25 @@ package com.bkm.worktalk;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
+import com.google.firebase.auth.FirebaseAuth;
+
 public class FragSettings extends Fragment {
+
+    private FirebaseAuth mAuth;
 
     Button btn_settings_profile_photo_change,
            btn_settings_user_edit,
@@ -27,6 +35,8 @@ public class FragSettings extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.activity_frag_settings, container, false);
 
+        mAuth = FirebaseAuth.getInstance();
+
         btn_settings_profile_photo_change = view.findViewById(R.id.btn_settings_profile_photo_change);
         btn_settings_user_edit = view.findViewById(R.id.btn_settings_user_edit);
         btn_settings_user_alarm = view.findViewById(R.id.btn_settings_user_alarm);
@@ -38,15 +48,18 @@ public class FragSettings extends Fragment {
         btn_settings_user_signout.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                showAlert("로그아웃");
+
+                mAuth.signOut();
+
+                Login login = new Login();
+                login.setChk_signOut(true);
+
+                Intent i = new Intent(getActivity(), Login.class);
+                i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                startActivity(i);
+
             }
         });
-
-
-
-
-
-
 
         return view;
     }

--- a/app/src/main/java/com/bkm/worktalk/Fragment.java
+++ b/app/src/main/java/com/bkm/worktalk/Fragment.java
@@ -4,13 +4,24 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 
 public class Fragment extends AppCompatActivity {
 
     private String myName, myDept, myUid;
+    private static boolean chk_finish = false;
+
+    public boolean isChk_finish() {
+        return chk_finish;
+    }
+
+    public void setChk_finish(boolean chk_finish) {
+        this.chk_finish = chk_finish;
+    }
 
     private FragmentManager fragmentManager;
     private FragProject fragProject;
@@ -67,4 +78,14 @@ public class Fragment extends AppCompatActivity {
             }
         }
     };
+
+    public void signOutFinish() {
+
+        Login login = new Login();
+        login.setChk_signOut(true);
+
+        Intent intent = new Intent(Fragment.this, Login.class);
+        startActivity(intent);
+        finish();
+    }
 }

--- a/app/src/main/java/com/bkm/worktalk/Login.java
+++ b/app/src/main/java/com/bkm/worktalk/Login.java
@@ -39,6 +39,16 @@ public class Login extends AppCompatActivity {
     private DatabaseReference mDatabase;
     private SharedPreferences appData;
 
+    private static boolean chk_signOut = false;
+
+    public boolean isChk_signOut() {
+        return chk_signOut;
+    }
+
+    public void setChk_signOut(boolean chk_signOut) {
+        this.chk_signOut = chk_signOut;
+    }
+
     EditText et_mail_login, et_pw_login;
     ImageButton ib_all_del1_login, ib_all_del2_login;
     Button btn_login, btn_transJoin, btn_selAccount, btn_selPw;
@@ -186,7 +196,15 @@ public class Login extends AppCompatActivity {
         String myName = appData.getString("myName", "");
         String myDept = appData.getString("myDept", "");
 
-        if(!myUid.equals("")) {
+        if(chk_signOut) {
+            SharedPreferences.Editor editor = appData.edit();
+
+            editor.putString("myUid", "");
+            editor.apply();
+
+            chk_signOut = false;
+        }
+        else if(!myUid.equals("")) {
             Intent intent = new Intent(getApplication(), Fragment.class);
             intent.putExtra("myName", myName);
             intent.putExtra("myDept", myDept);


### PR DESCRIPTION
A프래그먼트에서 B프래그먼트(메인 액티비티)를 피니시 하고
로그인 액티비티로 넘겨 로그인을 할 수 있도록 작업을 함.

여기서 기존의 로그인 정보는 메인 액티비티를 피니시 할 때,
클린(로그아웃) 작업을 해줬기 때문에 로그인 액티비티로 넘어갔을 경우,
로그아웃 상태로 시작하게 됩니다.

단순한 작업인데 4시간이나 걸렸던 이유 :
if문의 이해부족으로 else if를 사용하는 자리에서 if를 사용하여
if문이 다 따로 작업이 됬기 때문이었습니다.
 - 원래는 if문 하나가 조건에 맞을 경우 다른 if문은 작동이
   되지 않아야 됬던 작업이었지만, else if를 사용하지 않아
   이런 불상사가 일어났던 거 였습니다.