### PR TITLE
BKM 13 update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,4 +55,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    implementation "androidx.work:work-runtime:2.7.1"
 }

--- a/app/src/main/java/com/bkm/worktalk/FirebaseMessagingService.java
+++ b/app/src/main/java/com/bkm/worktalk/FirebaseMessagingService.java
@@ -58,8 +58,10 @@ public class FirebaseMessagingService extends com.google.firebase.messaging.Fire
         notificationIntent.putExtra("chatRoomPath", chatRoomPath);
         notificationIntent.putExtra("myUid", myUid);
 
+        // 버전이 높아져서 pendingIntent getActivity 파라미터에 PendingIntent.FLAG_MUTABLE를 꼭 써줘야 함.
+        // 예전 소스에는 이 부분이 없어서 구버전 폰에서는 잘 됐지만, 신버전 폰일 경우 앱이 꺼지는 문제가 있었음.
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, (int) System.currentTimeMillis(), notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, (int) System.currentTimeMillis(), notificationIntent, PendingIntent.FLAG_MUTABLE);
 
         // 1. 알림 메시지를 관리하는 notificationManager 객체 추출
         NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);


### PR DESCRIPTION
버전차이로 인해 버전이 높은 폰으로 앱을 실행시켰을 경우,
알림을 받거나 다른 사람이 채팅을 보냈을 때 앱이 꺼지는
버그가 발생해서 버그를 수정하여 다시 올렸습니다.